### PR TITLE
Fix DynamoDB projection syntax error

### DIFF
--- a/terraform/modules/dynamodb_table/main.tf
+++ b/terraform/modules/dynamodb_table/main.tf
@@ -25,17 +25,11 @@ resource "aws_dynamodb_table" "table" {
   dynamic "global_secondary_index" {
     for_each = var.global_secondary_indexes
     content {
-      name            = global_secondary_index.value.name
-      hash_key        = global_secondary_index.value.hash_key
-      range_key       = lookup(global_secondary_index.value, "range_key", null)
-      projection_type = global_secondary_index.value.projection_type
-
-      dynamic "projection" {
-        for_each = lookup(global_secondary_index.value, "non_key_attributes", null) != null ? [1] : []
-        content {
-          non_key_attributes = global_secondary_index.value.non_key_attributes
-        }
-      }
+      name               = global_secondary_index.value.name
+      hash_key           = global_secondary_index.value.hash_key
+      range_key          = lookup(global_secondary_index.value, "range_key", null)
+      projection_type    = global_secondary_index.value.projection_type
+      non_key_attributes = lookup(global_secondary_index.value, "non_key_attributes", null)
     }
   }
 


### PR DESCRIPTION
## Summary

Fixed Terraform deployment error caused by invalid `dynamic "projection"` block in DynamoDB table configuration.

## Changes

- Removed invalid `dynamic "projection"` block from `global_secondary_index`
- Added `non_key_attributes` as a direct attribute within the `global_secondary_index` content block
- This matches the correct Terraform AWS provider syntax for DynamoDB indexes

## Files Modified

- `terraform/modules/dynamodb_table/main.tf`

Resolves #6

Generated with [Claude Code](https://claude.ai/code)