### PR TITLE
Fix: Lambda Function Environment Name Extraction

### DIFF
--- a/terraform/root.hcl
+++ b/terraform/root.hcl
@@ -7,9 +7,13 @@ locals {
   region       = "us-east-2"
   region_abbr  = "use2"
 
-  # Parse environment from the directory name (either "dev" or "prod")
-  parsed_path = split("/", get_terragrunt_dir())
-  environment = element(local.parsed_path, length(local.parsed_path) - 1)
+  # Parse environment from the directory structure
+  # The terragrunt.hcl files are in terraform/environments/{env}/
+  # Use path_relative_to_include() to get the relative path from root.hcl
+  # This will be "environments/dev" or "environments/prod"
+  relative_path = path_relative_to_include()
+  parsed_path   = split("/", local.relative_path)
+  environment   = length(local.parsed_path) > 1 ? element(local.parsed_path, 1) : "dev"
 
   # Common naming convention: {environment}-{region}-{project}-{resource_type}-{resource_name}
   name_prefix = "${local.environment}-${local.region_abbr}-${local.project_name}"


### PR DESCRIPTION
## Summary

Fixed the environment extraction logic in Terragrunt root.hcl to correctly identify dev/prod environments, ensuring Lambda functions are named with the proper environment prefix.

## Changes

- Modified `terraform/root.hcl` to use `path_relative_to_include()` instead of `get_terragrunt_dir()`
- This ensures reliable environment extraction regardless of where Terragrunt is invoked
- Lambda functions will now be named correctly:
  - `dev-use2-pantry-lambda-core-api` for dev environment
  - `prod-use2-pantry-lambda-core-api` for prod environment

## Testing

After merging, run `terragrunt apply` from `terraform/environments/dev/` to recreate the Lambda function with the correct name.

Fixes #8

## Affected Code Owners

@sp-loomis - Changes to Terraform infrastructure configuration

Generated with [Claude Code](https://claude.ai/code)