### PR TITLE
feat: Add multiple quantity dimensions per item

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -129,17 +129,22 @@ def create_item():
     """Create a new inventory item with optional dimensions."""
     try:
         data = app.current_event.json_body
+        logger.info(f"Received request body: {data}")
+        dimensions_from_request = data.get('dimensions', [])
+        logger.info(f"Extracted dimensions: {dimensions_from_request}")
+
         item = item_service.create_item(
             name=data['name'],
             location_id=data['location_id'],
             quantity=data.get('quantity', 1),
             unit=data.get('unit', 'unit'),
-            dimensions=data.get('dimensions', []),
+            dimensions=dimensions_from_request,
             use_by_date=data.get('use_by_date'),
             tags=data.get('tags', []),
             notes=data.get('notes', '')
         )
         metrics.add_metric(name="ItemCreated", unit="Count", value=1)
+        logger.info(f"Created item with dimensions: {item.get('dimensions')}")
         return {"item": item}, 201
     except ValueError as e:
         logger.warning(f"Validation error creating item: {str(e)}")

--- a/backend/dimensions.py
+++ b/backend/dimensions.py
@@ -1,0 +1,225 @@
+"""
+Dimension models and unit conversion utilities for the Pantry App.
+
+Supports Count, Weight, and Volume dimensions with automatic unit conversion.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, List, Dict, Any
+from enum import Enum
+from decimal import Decimal
+
+
+class DimensionType(str, Enum):
+    """Types of dimensions that can be attached to items."""
+    COUNT = "count"
+    WEIGHT = "weight"
+    VOLUME = "volume"
+
+
+class WeightUnit(str, Enum):
+    """Weight units with conversion factors to grams (base unit)."""
+    GRAM = "g"
+    KILOGRAM = "kg"
+    OUNCE = "oz"
+    POUND = "lb"
+
+
+class VolumeUnit(str, Enum):
+    """Volume units with conversion factors to milliliters (base unit)."""
+    MILLILITER = "ml"
+    LITER = "l"
+    TEASPOON = "tsp"
+    TABLESPOON = "tbsp"
+    FLUID_OUNCE = "fl oz"
+    CUP = "cup"
+    PINT = "pint"
+    QUART = "quart"
+    GALLON = "gallon"
+
+
+# Conversion factors to base units
+WEIGHT_TO_GRAMS = {
+    WeightUnit.GRAM: Decimal("1"),
+    WeightUnit.KILOGRAM: Decimal("1000"),
+    WeightUnit.OUNCE: Decimal("28.349523125"),
+    WeightUnit.POUND: Decimal("453.59237"),
+}
+
+VOLUME_TO_ML = {
+    VolumeUnit.MILLILITER: Decimal("1"),
+    VolumeUnit.LITER: Decimal("1000"),
+    VolumeUnit.TEASPOON: Decimal("4.92892"),
+    VolumeUnit.TABLESPOON: Decimal("14.7868"),
+    VolumeUnit.FLUID_OUNCE: Decimal("29.5735"),
+    VolumeUnit.CUP: Decimal("236.588"),
+    VolumeUnit.PINT: Decimal("473.176"),
+    VolumeUnit.QUART: Decimal("946.353"),
+    VolumeUnit.GALLON: Decimal("3785.41"),
+}
+
+
+@dataclass
+class Dimension:
+    """Represents a single dimension (count, weight, or volume) of an item."""
+    dimension_type: DimensionType
+    value: Decimal
+    unit: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for storage."""
+        return {
+            "dimension_type": self.dimension_type.value,
+            "value": float(self.value),
+            "unit": self.unit
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Dimension":
+        """Create from dictionary."""
+        return cls(
+            dimension_type=DimensionType(data["dimension_type"]),
+            value=Decimal(str(data["value"])),
+            unit=data["unit"]
+        )
+
+    def to_base_unit(self) -> Decimal:
+        """Convert this dimension to its base unit value."""
+        if self.dimension_type == DimensionType.COUNT:
+            return self.value
+        elif self.dimension_type == DimensionType.WEIGHT:
+            return self.value * WEIGHT_TO_GRAMS.get(WeightUnit(self.unit), Decimal("1"))
+        elif self.dimension_type == DimensionType.VOLUME:
+            return self.value * VOLUME_TO_ML.get(VolumeUnit(self.unit), Decimal("1"))
+        return self.value
+
+    @classmethod
+    def from_base_unit(cls, dimension_type: DimensionType, base_value: Decimal, target_unit: str) -> "Dimension":
+        """Create a dimension from a base unit value, converting to target unit."""
+        if dimension_type == DimensionType.COUNT:
+            return cls(dimension_type=dimension_type, value=base_value, unit="units")
+        elif dimension_type == DimensionType.WEIGHT:
+            conversion_factor = WEIGHT_TO_GRAMS.get(WeightUnit(target_unit), Decimal("1"))
+            return cls(
+                dimension_type=dimension_type,
+                value=base_value / conversion_factor,
+                unit=target_unit
+            )
+        elif dimension_type == DimensionType.VOLUME:
+            conversion_factor = VOLUME_TO_ML.get(VolumeUnit(target_unit), Decimal("1"))
+            return cls(
+                dimension_type=dimension_type,
+                value=base_value / conversion_factor,
+                unit=target_unit
+            )
+        return cls(dimension_type=dimension_type, value=base_value, unit=target_unit)
+
+
+def aggregate_dimensions(items: List[Dict[str, Any]]) -> Dict[str, Dimension]:
+    """
+    Aggregate dimensions across multiple items.
+
+    Returns a dictionary mapping dimension type to aggregated dimension in an appropriate unit.
+    """
+    # Accumulate base unit values for each dimension type
+    base_totals: Dict[DimensionType, Decimal] = {}
+
+    for item in items:
+        dimensions = item.get("dimensions", [])
+        for dim_data in dimensions:
+            dim = Dimension.from_dict(dim_data)
+            dim_type = dim.dimension_type
+
+            if dim_type not in base_totals:
+                base_totals[dim_type] = Decimal("0")
+
+            base_totals[dim_type] += dim.to_base_unit()
+
+    # Convert to appropriate units
+    result = {}
+    for dim_type, base_value in base_totals.items():
+        if base_value == 0:
+            continue
+
+        if dim_type == DimensionType.COUNT:
+            result[dim_type.value] = Dimension(
+                dimension_type=dim_type,
+                value=base_value,
+                unit="units"
+            )
+        elif dim_type == DimensionType.WEIGHT:
+            result[dim_type.value] = _convert_weight_to_appropriate_unit(base_value)
+        elif dim_type == DimensionType.VOLUME:
+            result[dim_type.value] = _convert_volume_to_appropriate_unit(base_value)
+
+    return result
+
+
+def _convert_weight_to_appropriate_unit(grams: Decimal) -> Dimension:
+    """Convert weight in grams to the most appropriate imperial unit."""
+    # Convert to pounds first
+    pounds = grams / WEIGHT_TO_GRAMS[WeightUnit.POUND]
+
+    if pounds >= 1:
+        return Dimension(
+            dimension_type=DimensionType.WEIGHT,
+            value=pounds,
+            unit=WeightUnit.POUND.value
+        )
+    else:
+        # Use ounces for smaller amounts
+        ounces = grams / WEIGHT_TO_GRAMS[WeightUnit.OUNCE]
+        return Dimension(
+            dimension_type=DimensionType.WEIGHT,
+            value=ounces,
+            unit=WeightUnit.OUNCE.value
+        )
+
+
+def _convert_volume_to_appropriate_unit(ml: Decimal) -> Dimension:
+    """Convert volume in milliliters to the most appropriate imperial unit."""
+    # Convert to various units and choose the most readable
+    gallons = ml / VOLUME_TO_ML[VolumeUnit.GALLON]
+    quarts = ml / VOLUME_TO_ML[VolumeUnit.QUART]
+    cups = ml / VOLUME_TO_ML[VolumeUnit.CUP]
+    fluid_ounces = ml / VOLUME_TO_ML[VolumeUnit.FLUID_OUNCE]
+
+    if gallons >= 1:
+        return Dimension(
+            dimension_type=DimensionType.VOLUME,
+            value=gallons,
+            unit=VolumeUnit.GALLON.value
+        )
+    elif quarts >= 1:
+        return Dimension(
+            dimension_type=DimensionType.VOLUME,
+            value=quarts,
+            unit=VolumeUnit.QUART.value
+        )
+    elif cups >= 1:
+        return Dimension(
+            dimension_type=DimensionType.VOLUME,
+            value=cups,
+            unit=VolumeUnit.CUP.value
+        )
+    else:
+        return Dimension(
+            dimension_type=DimensionType.VOLUME,
+            value=fluid_ounces,
+            unit=VolumeUnit.FLUID_OUNCE.value
+        )
+
+
+def validate_dimension(dimension_type: str, unit: str) -> bool:
+    """Validate that a unit is appropriate for a dimension type."""
+    try:
+        dim_type = DimensionType(dimension_type)
+        if dim_type == DimensionType.COUNT:
+            return unit == "units"
+        elif dim_type == DimensionType.WEIGHT:
+            return unit in [u.value for u in WeightUnit]
+        elif dim_type == DimensionType.VOLUME:
+            return unit in [u.value for u in VolumeUnit]
+        return False
+    except ValueError:
+        return False

--- a/backend/models.py
+++ b/backend/models.py
@@ -3,7 +3,7 @@ Data models for the Pantry App.
 """
 
 from dataclasses import dataclass, field
-from typing import Optional, List
+from typing import Optional, List, Dict, Any
 from datetime import datetime, timezone
 import uuid
 
@@ -39,13 +39,16 @@ class Location:
 
 @dataclass
 class Item:
-    """Inventory item model."""
+    """Inventory item model with support for multiple dimensions."""
     item_id: str
     name: str
     location_id: str
     item_name: str  # Normalized name for searching
+    # Legacy fields for backward compatibility
     quantity: float = 1.0
     unit: str = "unit"
+    # New dimension support
+    dimensions: List[Dict[str, Any]] = field(default_factory=list)
     use_by_date: Optional[str] = None
     notes: str = ""
     created_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
@@ -58,6 +61,7 @@ class Item:
         location_id: str,
         quantity: float = 1.0,
         unit: str = "unit",
+        dimensions: List[Dict[str, Any]] = None,
         use_by_date: Optional[str] = None,
         notes: str = ""
     ) -> "Item":
@@ -69,13 +73,14 @@ class Item:
             item_name=name.lower(),  # Normalized for searching
             quantity=quantity,
             unit=unit,
+            dimensions=dimensions or [],
             use_by_date=use_by_date,
             notes=notes
         )
 
     def to_dict(self) -> dict:
         """Convert to dictionary."""
-        return {
+        result = {
             "item_id": self.item_id,
             "name": self.name,
             "location_id": self.location_id,
@@ -87,6 +92,9 @@ class Item:
             "created_at": self.created_at,
             "updated_at": self.updated_at
         }
+        if self.dimensions:
+            result["dimensions"] = self.dimensions
+        return result
 
 
 @dataclass

--- a/backend/services.py
+++ b/backend/services.py
@@ -11,6 +11,9 @@ from boto3.dynamodb.conditions import Key, Attr
 from aws_lambda_powertools import Logger
 
 from models import Item, Location, ItemTag
+from dimensions import (
+    Dimension, DimensionType, validate_dimension, aggregate_dimensions
+)
 
 logger = Logger(child=True)
 
@@ -131,16 +134,29 @@ class ItemService:
         location_id: str,
         quantity: float = 1.0,
         unit: str = "unit",
+        dimensions: List[Dict[str, Any]] = None,
         use_by_date: Optional[str] = None,
         tags: List[str] = None,
         notes: str = ""
     ) -> Dict[str, Any]:
-        """Create a new inventory item."""
+        """Create a new inventory item with optional dimensions."""
+        # Validate dimensions if provided
+        if dimensions:
+            for dim in dimensions:
+                if not validate_dimension(dim.get("dimension_type"), dim.get("unit")):
+                    raise ValueError(f"Invalid dimension: {dim}")
+
+            # Ensure no duplicate dimension types
+            dim_types = [d.get("dimension_type") for d in dimensions]
+            if len(dim_types) != len(set(dim_types)):
+                raise ValueError("Duplicate dimension types not allowed")
+
         item = Item.create(
             name=name,
             location_id=location_id,
             quantity=Decimal(str(quantity)),
             unit=unit,
+            dimensions=dimensions or [],
             use_by_date=use_by_date,
             notes=notes
         )
@@ -253,7 +269,7 @@ class ItemService:
         return items
 
     def update_item(self, item_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
-        """Update an item."""
+        """Update an item, including dimensions."""
         item = self.get_item(item_id)
         if not item:
             return None
@@ -280,6 +296,21 @@ class ItemService:
             update_expr += ", #u = :unit"
             expr_values[":unit"] = updates["unit"]
             expr_names["#u"] = "unit"
+
+        if "dimensions" in updates:
+            # Validate dimensions
+            dimensions = updates["dimensions"]
+            for dim in dimensions:
+                if not validate_dimension(dim.get("dimension_type"), dim.get("unit")):
+                    raise ValueError(f"Invalid dimension: {dim}")
+
+            # Ensure no duplicate dimension types
+            dim_types = [d.get("dimension_type") for d in dimensions]
+            if len(dim_types) != len(set(dim_types)):
+                raise ValueError("Duplicate dimension types not allowed")
+
+            update_expr += ", dimensions = :dimensions"
+            expr_values[":dimensions"] = dimensions
 
         if "use_by_date" in updates:
             update_expr += ", use_by_date = :use_by_date"
@@ -383,8 +414,21 @@ class ItemService:
 
         return items
 
-    def get_aggregate_stats(self, location_id: Optional[str] = None, tag: Optional[str] = None) -> Dict[str, Any]:
-        """Get aggregate statistics for inventory."""
+    def get_aggregate_stats(
+        self,
+        location_id: Optional[str] = None,
+        tag: Optional[str] = None,
+        requested_units: Optional[Dict[str, str]] = None
+    ) -> Dict[str, Any]:
+        """
+        Get aggregate statistics for inventory with dimension support.
+
+        Args:
+            location_id: Filter by location
+            tag: Filter by tag
+            requested_units: Optional dict mapping dimension type to desired unit
+                            e.g., {"weight": "kg", "volume": "gallon"}
+        """
         if location_id:
             items = self.get_items_by_location(location_id)
         elif tag:
@@ -396,16 +440,37 @@ class ItemService:
         total_quantity = sum(item.get("quantity", 0) for item in items)
         items_with_expiry = sum(1 for item in items if item.get("use_by_date"))
 
-        # Group by unit
+        # Legacy: Group by unit
         quantities_by_unit = {}
         for item in items:
             unit = item.get("unit", "unit")
             quantity = item.get("quantity", 0)
             quantities_by_unit[unit] = quantities_by_unit.get(unit, 0) + quantity
 
+        # New: Aggregate dimensions
+        aggregated_dimensions = aggregate_dimensions(items)
+
+        # Convert to requested units if specified
+        if requested_units:
+            for dim_type_str, target_unit in requested_units.items():
+                if dim_type_str in aggregated_dimensions:
+                    dim = aggregated_dimensions[dim_type_str]
+                    base_value = dim.to_base_unit()
+                    dim_type = DimensionType(dim_type_str)
+                    aggregated_dimensions[dim_type_str] = Dimension.from_base_unit(
+                        dim_type, base_value, target_unit
+                    )
+
+        # Convert dimensions to dict format
+        dimensions_dict = {
+            dim_type: dim.to_dict()
+            for dim_type, dim in aggregated_dimensions.items()
+        }
+
         return {
             "total_items": total_items,
             "total_quantity": total_quantity,
             "items_with_expiry": items_with_expiry,
-            "quantities_by_unit": quantities_by_unit
+            "quantities_by_unit": quantities_by_unit,
+            "aggregated_dimensions": dimensions_dict
         }

--- a/backend/services.py
+++ b/backend/services.py
@@ -163,6 +163,13 @@ class ItemService:
 
         item_dict = item.to_dict()
         item_dict["quantity"] = Decimal(str(item_dict["quantity"]))
+
+        # Convert dimension values to Decimal for DynamoDB
+        if "dimensions" in item_dict and item_dict["dimensions"]:
+            for dim in item_dict["dimensions"]:
+                if "value" in dim:
+                    dim["value"] = Decimal(str(dim["value"]))
+
         self.items_table.put_item(Item=item_dict)
 
         if tags:
@@ -186,6 +193,12 @@ class ItemService:
         if "quantity" in item:
             item["quantity"] = float(item["quantity"])
 
+        # Convert dimension values from Decimal to float
+        if "dimensions" in item and item["dimensions"]:
+            for dim in item["dimensions"]:
+                if "value" in dim:
+                    dim["value"] = float(dim["value"])
+
         # Add tags
         item["tags"] = self.tag_service.get_tags_for_item(item_id)
         return item
@@ -199,6 +212,11 @@ class ItemService:
         for item in items:
             if "quantity" in item:
                 item["quantity"] = float(item["quantity"])
+            # Convert dimension values from Decimal to float
+            if "dimensions" in item and item["dimensions"]:
+                for dim in item["dimensions"]:
+                    if "value" in dim:
+                        dim["value"] = float(dim["value"])
             item["tags"] = self.tag_service.get_tags_for_item(item["item_id"])
 
         return items
@@ -214,6 +232,11 @@ class ItemService:
         for item in items:
             if "quantity" in item:
                 item["quantity"] = float(item["quantity"])
+            # Convert dimension values from Decimal to float
+            if "dimensions" in item and item["dimensions"]:
+                for dim in item["dimensions"]:
+                    if "value" in dim:
+                        dim["value"] = float(dim["value"])
             item["tags"] = self.tag_service.get_tags_for_item(item["item_id"])
 
         return items
@@ -241,6 +264,11 @@ class ItemService:
         for item in items:
             if "quantity" in item:
                 item["quantity"] = float(item["quantity"])
+            # Convert dimension values from Decimal to float
+            if "dimensions" in item and item["dimensions"]:
+                for dim in item["dimensions"]:
+                    if "value" in dim:
+                        dim["value"] = float(dim["value"])
             item["tags"] = self.tag_service.get_tags_for_item(item["item_id"])
 
         return items
@@ -264,6 +292,11 @@ class ItemService:
         for item in items:
             if "quantity" in item:
                 item["quantity"] = float(item["quantity"])
+            # Convert dimension values from Decimal to float
+            if "dimensions" in item and item["dimensions"]:
+                for dim in item["dimensions"]:
+                    if "value" in dim:
+                        dim["value"] = float(dim["value"])
             item["tags"] = self.tag_service.get_tags_for_item(item["item_id"])
 
         return items
@@ -309,6 +342,11 @@ class ItemService:
             if len(dim_types) != len(set(dim_types)):
                 raise ValueError("Duplicate dimension types not allowed")
 
+            # Convert dimension values to Decimal for DynamoDB
+            for dim in dimensions:
+                if "value" in dim:
+                    dim["value"] = Decimal(str(dim["value"]))
+
             update_expr += ", dimensions = :dimensions"
             expr_values[":dimensions"] = dimensions
 
@@ -346,6 +384,11 @@ class ItemService:
 
         if updated_item and "quantity" in updated_item:
             updated_item["quantity"] = float(updated_item["quantity"])
+        # Convert dimension values from Decimal to float
+        if updated_item and "dimensions" in updated_item and updated_item["dimensions"]:
+            for dim in updated_item["dimensions"]:
+                if "value" in dim:
+                    dim["value"] = float(dim["value"])
         updated_item["tags"] = self.tag_service.get_tags_for_item(item_id)
 
         return updated_item

--- a/backend/services.py
+++ b/backend/services.py
@@ -140,6 +140,9 @@ class ItemService:
         notes: str = ""
     ) -> Dict[str, Any]:
         """Create a new inventory item with optional dimensions."""
+        # Debug logging
+        logger.info(f"create_item called with dimensions: {dimensions}")
+
         # Validate dimensions if provided
         if dimensions:
             for dim in dimensions:
@@ -156,12 +159,13 @@ class ItemService:
             location_id=location_id,
             quantity=Decimal(str(quantity)),
             unit=unit,
-            dimensions=dimensions or [],
+            dimensions=dimensions if dimensions is not None else [],
             use_by_date=use_by_date,
             notes=notes
         )
 
         item_dict = item.to_dict()
+        logger.info(f"Item dict before Decimal conversion: {item_dict}")
         item_dict["quantity"] = Decimal(str(item_dict["quantity"]))
 
         # Convert dimension values to Decimal for DynamoDB
@@ -170,7 +174,9 @@ class ItemService:
                 if "value" in dim:
                     dim["value"] = Decimal(str(dim["value"]))
 
+        logger.info(f"Item dict after Decimal conversion (about to write to DynamoDB): {item_dict}")
         self.items_table.put_item(Item=item_dict)
+        logger.info("Successfully wrote item to DynamoDB")
 
         if tags:
             self.tag_service.add_tags_to_item(item.item_id, tags)

--- a/backend/test_dimensions.py
+++ b/backend/test_dimensions.py
@@ -1,0 +1,298 @@
+"""
+Unit tests for dimension functionality.
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import unittest
+from decimal import Decimal
+from dimensions import (
+    Dimension, DimensionType, WeightUnit, VolumeUnit,
+    aggregate_dimensions, validate_dimension,
+    WEIGHT_TO_GRAMS, VOLUME_TO_ML
+)
+
+
+class TestDimension(unittest.TestCase):
+    """Test the Dimension class."""
+
+    def test_create_count_dimension(self):
+        """Test creating a count dimension."""
+        dim = Dimension(
+            dimension_type=DimensionType.COUNT,
+            value=Decimal("5"),
+            unit="units"
+        )
+        self.assertEqual(dim.dimension_type, DimensionType.COUNT)
+        self.assertEqual(dim.value, Decimal("5"))
+        self.assertEqual(dim.unit, "units")
+
+    def test_create_weight_dimension(self):
+        """Test creating a weight dimension."""
+        dim = Dimension(
+            dimension_type=DimensionType.WEIGHT,
+            value=Decimal("2.5"),
+            unit=WeightUnit.POUND.value
+        )
+        self.assertEqual(dim.dimension_type, DimensionType.WEIGHT)
+        self.assertEqual(dim.value, Decimal("2.5"))
+        self.assertEqual(dim.unit, "lb")
+
+    def test_create_volume_dimension(self):
+        """Test creating a volume dimension."""
+        dim = Dimension(
+            dimension_type=DimensionType.VOLUME,
+            value=Decimal("1"),
+            unit=VolumeUnit.GALLON.value
+        )
+        self.assertEqual(dim.dimension_type, DimensionType.VOLUME)
+        self.assertEqual(dim.value, Decimal("1"))
+        self.assertEqual(dim.unit, "gallon")
+
+    def test_to_dict(self):
+        """Test converting dimension to dictionary."""
+        dim = Dimension(
+            dimension_type=DimensionType.WEIGHT,
+            value=Decimal("10"),
+            unit=WeightUnit.KILOGRAM.value
+        )
+        dim_dict = dim.to_dict()
+        self.assertEqual(dim_dict["dimension_type"], "weight")
+        self.assertEqual(dim_dict["value"], 10.0)
+        self.assertEqual(dim_dict["unit"], "kg")
+
+    def test_from_dict(self):
+        """Test creating dimension from dictionary."""
+        dim_dict = {
+            "dimension_type": "volume",
+            "value": 2.5,
+            "unit": "cup"
+        }
+        dim = Dimension.from_dict(dim_dict)
+        self.assertEqual(dim.dimension_type, DimensionType.VOLUME)
+        self.assertEqual(dim.value, Decimal("2.5"))
+        self.assertEqual(dim.unit, "cup")
+
+    def test_weight_to_base_unit(self):
+        """Test converting weight to base unit (grams)."""
+        # 2 pounds to grams
+        dim = Dimension(
+            dimension_type=DimensionType.WEIGHT,
+            value=Decimal("2"),
+            unit=WeightUnit.POUND.value
+        )
+        base_value = dim.to_base_unit()
+        expected = Decimal("2") * WEIGHT_TO_GRAMS[WeightUnit.POUND]
+        self.assertEqual(base_value, expected)
+
+    def test_volume_to_base_unit(self):
+        """Test converting volume to base unit (milliliters)."""
+        # 1 gallon to milliliters
+        dim = Dimension(
+            dimension_type=DimensionType.VOLUME,
+            value=Decimal("1"),
+            unit=VolumeUnit.GALLON.value
+        )
+        base_value = dim.to_base_unit()
+        expected = VOLUME_TO_ML[VolumeUnit.GALLON]
+        self.assertEqual(base_value, expected)
+
+    def test_count_to_base_unit(self):
+        """Test that count dimensions don't need conversion."""
+        dim = Dimension(
+            dimension_type=DimensionType.COUNT,
+            value=Decimal("10"),
+            unit="units"
+        )
+        base_value = dim.to_base_unit()
+        self.assertEqual(base_value, Decimal("10"))
+
+    def test_from_base_unit_weight(self):
+        """Test creating weight dimension from base unit."""
+        # 1000 grams to kilograms
+        dim = Dimension.from_base_unit(
+            DimensionType.WEIGHT,
+            Decimal("1000"),
+            WeightUnit.KILOGRAM.value
+        )
+        self.assertEqual(dim.dimension_type, DimensionType.WEIGHT)
+        self.assertEqual(dim.value, Decimal("1"))
+        self.assertEqual(dim.unit, "kg")
+
+    def test_from_base_unit_volume(self):
+        """Test creating volume dimension from base unit."""
+        # 3785.41 ml to gallons
+        dim = Dimension.from_base_unit(
+            DimensionType.VOLUME,
+            Decimal("3785.41"),
+            VolumeUnit.GALLON.value
+        )
+        self.assertEqual(dim.dimension_type, DimensionType.VOLUME)
+        self.assertAlmostEqual(float(dim.value), 1.0, places=2)
+        self.assertEqual(dim.unit, "gallon")
+
+
+class TestValidation(unittest.TestCase):
+    """Test dimension validation."""
+
+    def test_validate_count_dimension(self):
+        """Test validating count dimensions."""
+        self.assertTrue(validate_dimension("count", "units"))
+        self.assertFalse(validate_dimension("count", "lb"))
+
+    def test_validate_weight_dimension(self):
+        """Test validating weight dimensions."""
+        self.assertTrue(validate_dimension("weight", "lb"))
+        self.assertTrue(validate_dimension("weight", "kg"))
+        self.assertTrue(validate_dimension("weight", "oz"))
+        self.assertTrue(validate_dimension("weight", "g"))
+        self.assertFalse(validate_dimension("weight", "cup"))
+
+    def test_validate_volume_dimension(self):
+        """Test validating volume dimensions."""
+        self.assertTrue(validate_dimension("volume", "gallon"))
+        self.assertTrue(validate_dimension("volume", "cup"))
+        self.assertTrue(validate_dimension("volume", "ml"))
+        self.assertFalse(validate_dimension("volume", "lb"))
+
+    def test_validate_invalid_type(self):
+        """Test validation with invalid dimension type."""
+        self.assertFalse(validate_dimension("invalid", "units"))
+
+
+class TestAggregation(unittest.TestCase):
+    """Test dimension aggregation."""
+
+    def test_aggregate_single_dimension_type(self):
+        """Test aggregating items with same dimension type."""
+        items = [
+            {
+                "dimensions": [
+                    {"dimension_type": "weight", "value": 1.0, "unit": "lb"}
+                ]
+            },
+            {
+                "dimensions": [
+                    {"dimension_type": "weight", "value": 16.0, "unit": "oz"}
+                ]
+            }
+        ]
+
+        result = aggregate_dimensions(items)
+        self.assertIn("weight", result)
+
+        # 1 lb + 16 oz = 2 lb total
+        weight_dim = result["weight"]
+        self.assertEqual(weight_dim.dimension_type, DimensionType.WEIGHT)
+        self.assertAlmostEqual(float(weight_dim.value), 2.0, places=1)
+
+    def test_aggregate_multiple_dimension_types(self):
+        """Test aggregating items with different dimension types."""
+        items = [
+            {
+                "dimensions": [
+                    {"dimension_type": "count", "value": 5.0, "unit": "units"},
+                    {"dimension_type": "weight", "value": 1.0, "unit": "lb"}
+                ]
+            },
+            {
+                "dimensions": [
+                    {"dimension_type": "count", "value": 3.0, "unit": "units"},
+                    {"dimension_type": "volume", "value": 2.0, "unit": "cup"}
+                ]
+            }
+        ]
+
+        result = aggregate_dimensions(items)
+
+        # Check count
+        self.assertIn("count", result)
+        count_dim = result["count"]
+        self.assertEqual(float(count_dim.value), 8.0)
+
+        # Check weight
+        self.assertIn("weight", result)
+        weight_dim = result["weight"]
+        self.assertAlmostEqual(float(weight_dim.value), 1.0, places=1)
+
+        # Check volume
+        self.assertIn("volume", result)
+
+    def test_aggregate_empty_dimensions(self):
+        """Test aggregating items with no dimensions."""
+        items = [
+            {"dimensions": []},
+            {"dimensions": []}
+        ]
+
+        result = aggregate_dimensions(items)
+        self.assertEqual(len(result), 0)
+
+    def test_aggregate_zero_values_not_reported(self):
+        """Test that zero dimension values are not reported."""
+        items = [
+            {
+                "dimensions": [
+                    {"dimension_type": "weight", "value": 1.0, "unit": "lb"}
+                ]
+            }
+        ]
+
+        result = aggregate_dimensions(items)
+
+        # Should only have weight, not count or volume
+        self.assertIn("weight", result)
+        self.assertNotIn("count", result)
+        self.assertNotIn("volume", result)
+
+    def test_aggregate_volume_unit_scaling(self):
+        """Test that volume aggregation scales to appropriate units."""
+        items = [
+            {
+                "dimensions": [
+                    {"dimension_type": "volume", "value": 1.0, "unit": "gallon"}
+                ]
+            },
+            {
+                "dimensions": [
+                    {"dimension_type": "volume", "value": 1.0, "unit": "gallon"}
+                ]
+            }
+        ]
+
+        result = aggregate_dimensions(items)
+        self.assertIn("volume", result)
+
+        # 2 gallons should be reported in gallons
+        volume_dim = result["volume"]
+        self.assertAlmostEqual(float(volume_dim.value), 2.0, places=1)
+        self.assertEqual(volume_dim.unit, "gallon")
+
+    def test_aggregate_weight_unit_scaling_to_ounces(self):
+        """Test that small weights are reported in ounces."""
+        items = [
+            {
+                "dimensions": [
+                    {"dimension_type": "weight", "value": 4.0, "unit": "oz"}
+                ]
+            },
+            {
+                "dimensions": [
+                    {"dimension_type": "weight", "value": 2.0, "unit": "oz"}
+                ]
+            }
+        ]
+
+        result = aggregate_dimensions(items)
+        self.assertIn("weight", result)
+
+        # 6 oz should be reported in ounces (less than 1 lb)
+        weight_dim = result["weight"]
+        self.assertEqual(weight_dim.unit, "oz")
+        self.assertAlmostEqual(float(weight_dim.value), 6.0, places=1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/cli/pantry_cli.py
+++ b/frontend/cli/pantry_cli.py
@@ -293,7 +293,7 @@ def add_item(name: str, location: str, quantity: float, unit: str, count: Option
     # Format dimensions for display
     dimensions_text = ""
     if item.get('dimensions'):
-        dimensions_text = "\nDimensions:\n"
+        dimensions_text = "Dimensions:\n"
         for dim in item['dimensions']:
             dim_type = dim['dimension_type'].capitalize()
             dimensions_text += f"  {dim_type}: {dim['value']} {dim['unit']}\n"
@@ -302,7 +302,7 @@ def add_item(name: str, location: str, quantity: float, unit: str, count: Option
         f"[green]Item added successfully![/green]\n\n"
         f"ID: {item['item_id']}\n"
         f"Name: {item['name']}\n"
-        f"Quantity: {item['quantity']} {item['unit']}" +
+        f"Quantity: {item['quantity']} {item['unit']}\n" +
         dimensions_text +
         f"Location: {item['location_id']}\n" +
         (f"Use by: {item['use_by_date']}\n" if item.get('use_by_date') else ""),
@@ -392,7 +392,7 @@ def get_item(item_id: str):
         f"ID: {item['item_id']}\n"
         f"Name: {item['name']}\n"
         f"Quantity: {item['quantity']} {item['unit']}\n" +
-        (dimensions_text if dimensions_text else "") +
+        dimensions_text +
         f"Location: {item['location_id']}\n"
         f"Use by: {item.get('use_by_date', 'N/A')}\n"
         f"Tags: {', '.join(item.get('tags', []))}\n"


### PR DESCRIPTION
## Summary

Implements support for multiple quantity dimensions per item as requested in #12.

### Changes
- Added comprehensive dimension support for Count, Weight, and Volume types
- Each item can have at most one dimension of each type
- Automatic unit conversion and intelligent scaling
- Updated API endpoints to accept/return dimensions
- Backward compatible with existing quantity/unit fields
- Comprehensive unit tests included

### Files Changed
- `backend/dimensions.py` (new)
- `backend/models.py`
- `backend/services.py`
- `backend/app.py`
- `backend/test_dimensions.py` (new)

Resolves #12

---
Generated with [Claude Code](https://claude.ai/code)